### PR TITLE
Feature/16 pass video config to zalenium

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
 - Add methods to install, purge, upgrade and start dogus
 - Add methods to run maven and yarn integration tests
+- Add parameters to test exection with yarn and maven
+  - boolean flag to control video recording
+  - argument list to pass additional environment variables
 
 ## [v1.0.0] - 2020-06-09
 First release of the dogu-build-lib!

--- a/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
@@ -152,16 +152,9 @@ class EcoSystem {
 
         script.timeout(time: timeoutInMinutes, unit: 'MINUTES') {
             try {
-                def defaultConfig = [seleniumVersion      : '3.141.59-p42',
-                                     seleniumImage        : 'elgalu/selenium',
-                                     zaleniumVersion      : '3.141.59z',
-                                     zaleniumImage        : 'dosel/zalenium',
-                                     zaleniumVideoDir     : 'zalenium',
-                                     debugZalenium        : false,
-                                     videoRecordingEnabled: enableVideoRecording,
-                                     sendGoogleAnalytics  : false]
+                def customConfig = [videoRecordingEnabled: enableVideoRecording]
                 script.withDockerNetwork { zaleniumNetwork ->
-                    script.withZalenium(defaultConfig, zaleniumNetwork) { zaleniumContainer, zaleniumIp, uid, gid ->
+                    script.withZalenium(customConfig, zaleniumNetwork) { zaleniumContainer, zaleniumIp, uid, gid ->
                         script.dir('integrationTests') {
                             script.docker.image(nodeImage).inside("${additionalContainerRunArgs}-e WEBDRIVER=remote -e CES_FQDN=${externalIP} -e SELENIUM_BROWSER=chrome -e SELENIUM_REMOTE_URL=http://${zaleniumIp}:4444/wd/hub") {
                                 script.sh 'yarn install'
@@ -191,16 +184,9 @@ class EcoSystem {
 
         script.timeout(time: timeoutInMinutes, unit: 'MINUTES') {
             try {
-                def defaultConfig = [seleniumVersion      : '3.141.59-p42',
-                                     seleniumImage        : 'elgalu/selenium',
-                                     zaleniumVersion      : '3.141.59z',
-                                     zaleniumImage        : 'dosel/zalenium',
-                                     zaleniumVideoDir     : 'zalenium',
-                                     debugZalenium        : false,
-                                     videoRecordingEnabled: enableVideoRecording,
-                                     sendGoogleAnalytics  : false]
+                def customConfig = [videoRecordingEnabled: enableVideoRecording]
                 script.withDockerNetwork { zaleniumNetwork ->
-                    script.withZalenium(defaultConfig, zaleniumNetwork) { zaleniumContainer, zaleniumIp, uid, gid ->
+                    script.withZalenium(customConfig, zaleniumNetwork) { zaleniumContainer, zaleniumIp, uid, gid ->
                         this.startMavenIntegrationTests(additionalContainerRunArgs)
                     }
                 }

--- a/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
@@ -156,7 +156,7 @@ class EcoSystem {
                 script.withDockerNetwork { zaleniumNetwork ->
                     script.withZalenium(customConfig, zaleniumNetwork) { zaleniumContainer, zaleniumIp, uid, gid ->
                         script.dir('integrationTests') {
-                            script.docker.image(nodeImage).inside("${additionalContainerRunArgs}-e WEBDRIVER=remote -e CES_FQDN=${externalIP} -e SELENIUM_BROWSER=chrome -e SELENIUM_REMOTE_URL=http://${zaleniumIp}:4444/wd/hub") {
+                            script.docker.image(nodeImage).inside("--net ${zaleniumNetwork} ${additionalContainerRunArgs}-e WEBDRIVER=remote -e CES_FQDN=${externalIP} -e SELENIUM_BROWSER=chrome -e SELENIUM_REMOTE_URL=http://${zaleniumIp}:4444/wd/hub") {
                                 script.sh 'yarn install'
                                 script.sh 'yarn run ci-test'
                             }

--- a/test/com/cloudogu/ces/dogubuildlib/EcoSystemTest.groovy
+++ b/test/com/cloudogu/ces/dogubuildlib/EcoSystemTest.groovy
@@ -88,4 +88,17 @@ class EcoSystemTest {
         assert expected == result
     }
 
+    @Test
+    void testparseAdditionalIntegrationTestArgs(){
+        def input = ['ARG1=value1', 'ARG2=value2']
+        String expected = "-e ARG1=value1 -e ARG2=value2"
+        String result = EcoSystem.parseAdditionalIntegrationTestArgs(input)
+        assert expected == result
+
+        input = []
+        expected = ""
+        result = EcoSystem.parseAdditionalIntegrationTestArgs(input)
+        assert expected == result
+    }
+
 }


### PR DESCRIPTION
This PR adds two new parameters which can be passed to the test execution with yarn and maven:
- boolean flag for controlling video recording during tests
- argument list to pass additional environment variables

Resolves #16 