### PR TITLE
pass admin group to cypress via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ additionalDockerArgs: "",
 additionalCypressArgs: "",
 
 # CES admin group for cypress
-# (passed to container as CYPRESS_ADMIN_GROUP)
+# (passed via the cypress --env AdminGroup=... CLI flag)
 adminGroup: "CesAdministrators"
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ additionalDockerArgs: "",
 # Additional cypress argument
 additionalCypressArgs: "",
 
-# CES admin group for cypress
-# (passed via the cypress --env AdminGroup=... CLI flag)
-adminGroup: "CesAdministrators"
+# CES admin group, username, and password for cypress
+# (passed via the cypress --env AdminGroup=/AdminUsername=/AdminPassword=... CLI flags)
+adminGroup: "CesAdministrators",
+adminUsername: "ces-admin",
+adminPassword: "Ecosystem2016!"
 ```
 
 #### Functions

--- a/README.md
+++ b/README.md
@@ -149,7 +149,11 @@ timeoutInMinutes: 15,
 additionalDockerArgs: "",
 
 # Additional cypress argument
-additionalCypressArgs: ""
+additionalCypressArgs: "",
+
+# CES admin group for cypress
+# (passed to container as CYPRESS_ADMIN_GROUP)
+adminGroup: "CesAdministrators"
 ```
 
 #### Functions

--- a/README.md
+++ b/README.md
@@ -155,7 +155,14 @@ additionalCypressArgs: "",
 # (passed via the cypress --env AdminGroup=/AdminUsername=/AdminPassword=... CLI flags)
 adminGroup: "CesAdministrators",
 adminUsername: "ces-admin",
-adminPassword: "Ecosystem2016!"
+adminPassword: "Ecosystem2016!",
+
+# Extra --env values to pass to cypress, merged with (and able to override)
+# adminGroup/adminUsername/adminPassword. Use this rather than adding another
+# --env/-e flag via additionalCypressArgs - Cypress's CLI doesn't merge repeated
+# --env flags, so a second one there would silently replace this class's own
+# AdminGroup/AdminUsername/AdminPassword instead of adding to them.
+additionalEnv: [:]
 ```
 
 #### Functions

--- a/src/com/cloudogu/ces/dogubuildlib/Cypress.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/Cypress.groovy
@@ -34,7 +34,6 @@ class Cypress {
             // Create args for the docker run
             String dockerArgs = "--ipc=host"
             dockerArgs <<= " -e CYPRESS_BASE_URL=https://${externalIP}"
-            dockerArgs <<= " -e CYPRESS_ADMIN_GROUP=${this.config.adminGroup}"
             dockerArgs <<= " --entrypoint=''"
             dockerArgs <<= " -v ${script.pwd()}/${passwdPath}:/etc/passwd:ro"
             dockerArgs <<= " " + this.config.additionalDockerArgs
@@ -48,6 +47,7 @@ class Cypress {
                         cypressRunArgs <<= " --config video=" + this.config.enableVideo
                         cypressRunArgs <<= " --reporter junit"
                         cypressRunArgs <<= " --reporter-options mochaFile=cypress-reports/TEST-${runID}-[hash].xml"
+                        cypressRunArgs <<= " --env AdminGroup=" + this.config.adminGroup
                         cypressRunArgs <<= " " + this.config.additionalCypressArgs
                         script.sh "cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run ${cypressRunArgs}"
                     }
@@ -74,9 +74,9 @@ class Cypress {
      * @param vagrant The vagrant instance used to communicate with the EcoSystem. Is required to read the current
      * global admin group from the etcd.
      *
-     * @deprecated adminGroup is now passed to cypress via CYPRESS_ADMIN_GROUP automatically in
-     * EcoSystem.runCypressIntegrationTests(). This method is no longer used because patching
-     * shared workspace files will cause issues when running classic + multinode tests in parallel.
+     * @deprecated adminGroup is now passed to cypress via the --env AdminGroup=... CLI flag in
+     * runIntegrationTests(). This method is no longer used because patching shared workspace
+     * files will cause issues when running classic + multinode tests in parallel.
      */
     @Deprecated
     void updateCypressConfiguration(Vagrant vagrant) {

--- a/src/com/cloudogu/ces/dogubuildlib/Cypress.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/Cypress.groovy
@@ -10,7 +10,9 @@ class Cypress {
             timeoutInMinutes     : 15,
             additionalDockerArgs : "",
             additionalCypressArgs: "",
-            adminGroup           : "CesAdministrators"
+            adminGroup           : "CesAdministrators",
+            adminUsername        : "ces-admin",
+            adminPassword        : "Ecosystem2016!"
     ]
     def config
 
@@ -47,11 +49,17 @@ class Cypress {
                         cypressRunArgs <<= " --config video=" + this.config.enableVideo
                         cypressRunArgs <<= " --reporter junit"
                         cypressRunArgs <<= " --reporter-options mochaFile=cypress-reports/TEST-${runID}-[hash].xml"
-                        cypressRunArgs <<= " --env AdminGroup=" + this.config.adminGroup
+                        cypressRunArgs <<= " --env AdminGroup=" + singleQuoteWrap(this.config.adminGroup)
+                        cypressRunArgs <<= " --env AdminUsername=" + singleQuoteWrap(this.config.adminUsername)
+                        cypressRunArgs <<= " --env AdminPassword=" + singleQuoteWrap(this.config.adminPassword)
                         cypressRunArgs <<= " " + this.config.additionalCypressArgs
                         script.sh "cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run ${cypressRunArgs}"
                     }
         }
+    }
+
+    private static String singleQuoteWrap(String value) {
+        return "'" + value.replace("'", "'\\''") + "'"
     }
 
     /**

--- a/src/com/cloudogu/ces/dogubuildlib/Cypress.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/Cypress.groovy
@@ -9,7 +9,8 @@ class Cypress {
             enableScreenshots    : true,
             timeoutInMinutes     : 15,
             additionalDockerArgs : "",
-            additionalCypressArgs: ""
+            additionalCypressArgs: "",
+            adminGroup           : "CesAdministrators"
     ]
     def config
 
@@ -33,6 +34,7 @@ class Cypress {
             // Create args for the docker run
             String dockerArgs = "--ipc=host"
             dockerArgs <<= " -e CYPRESS_BASE_URL=https://${externalIP}"
+            dockerArgs <<= " -e CYPRESS_ADMIN_GROUP=${this.config.adminGroup}"
             dockerArgs <<= " --entrypoint=''"
             dockerArgs <<= " -v ${script.pwd()}/${passwdPath}:/etc/passwd:ro"
             dockerArgs <<= " " + this.config.additionalDockerArgs
@@ -71,7 +73,12 @@ class Cypress {
      *
      * @param vagrant The vagrant instance used to communicate with the EcoSystem. Is required to read the current
      * global admin group from the etcd.
+     *
+     * @deprecated adminGroup is now passed to cypress via CYPRESS_ADMIN_GROUP automatically in
+     * EcoSystem.runCypressIntegrationTests(). This method is no longer used because patching
+     * shared workspace files will cause issues when running classic + multinode tests in parallel.
      */
+    @Deprecated
     void updateCypressConfiguration(Vagrant vagrant) {
         def hasCypressJsonFile = script.fileExists('integrationTests/cypress.json')
         def newAdminGroup = vagrant.sshOut "etcdctl get /config/_global/admin_group"

--- a/src/com/cloudogu/ces/dogubuildlib/Cypress.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/Cypress.groovy
@@ -12,7 +12,13 @@ class Cypress {
             additionalCypressArgs: "",
             adminGroup           : "CesAdministrators",
             adminUsername        : "ces-admin",
-            adminPassword        : "Ecosystem2016!"
+            adminPassword        : "Ecosystem2016!",
+            // Extra --env values to pass to cypress, merged with (and able to override)
+            // adminGroup/adminUsername/adminPassword. Use this rather than adding another
+            // --env/-e flag via additionalCypressArgs - Cypress's CLI doesn't merge repeated
+            // --env flags, so a second one there would silently replace this class's own
+            // AdminGroup/AdminUsername/AdminPassword instead of adding to them.
+            additionalEnv        : [:]
     ]
     def config
 
@@ -45,13 +51,20 @@ class Cypress {
                         def runID = UUID.randomUUID().toString()
                         String cypressRunArgs = "-q"
                         cypressRunArgs <<= " --headless"
-                        cypressRunArgs <<= " --config screenshotOnRunFailure=" + this.config.enableScreenshots
-                        cypressRunArgs <<= " --config video=" + this.config.enableVideo
+                        // Cypress's CLI doesn't merge repeated --config/--env flags!
+                        // Last occurrence silently wins, so we need to build one combined flag.
+                        cypressRunArgs <<= " --config " + joinAsCypressArgValue([
+                                screenshotOnRunFailure: this.config.enableScreenshots,
+                                video                 : this.config.enableVideo
+                        ])
                         cypressRunArgs <<= " --reporter junit"
                         cypressRunArgs <<= " --reporter-options mochaFile=cypress-reports/TEST-${runID}-[hash].xml"
-                        cypressRunArgs <<= " --env AdminGroup=" + singleQuoteWrap(this.config.adminGroup)
-                        cypressRunArgs <<= " --env AdminUsername=" + singleQuoteWrap(this.config.adminUsername)
-                        cypressRunArgs <<= " --env AdminPassword=" + singleQuoteWrap(this.config.adminPassword)
+                        def envVars = [
+                                AdminGroup   : this.config.adminGroup,
+                                AdminUsername: this.config.adminUsername,
+                                AdminPassword: this.config.adminPassword
+                        ] + this.config.additionalEnv
+                        cypressRunArgs <<= " --env " + joinAsCypressArgValue(envVars, true)
                         cypressRunArgs <<= " " + this.config.additionalCypressArgs
                         script.sh "cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run ${cypressRunArgs}"
                     }
@@ -60,6 +73,16 @@ class Cypress {
 
     private static String singleQuoteWrap(String value) {
         return "'" + value.replace("'", "'\\''") + "'"
+    }
+
+    /**
+     * Joins args into comma-separated key=value args for Cypress CLI.
+     */
+    private static String joinAsCypressArgValue(Map<String, ?> entries, boolean quoteValues = false) {
+        return entries.collect { key, value ->
+            String stringValue = value.toString()
+            "${key}=" + (quoteValues ? singleQuoteWrap(stringValue) : stringValue)
+        }.join(",")
     }
 
     /**

--- a/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
@@ -160,6 +160,8 @@ class EcoSystem {
 
         script.echo "Changing /config/_global/admin_group to $newGlobalAdminGroup"
         this.vagrant.ssh "etcdctl set /config/_global/admin_group $newGlobalAdminGroup"
+
+        currentConfig.adminGroup = newGlobalAdminGroup
     }
 
     /**
@@ -320,12 +322,13 @@ class EcoSystem {
      * <li>timeoutInMinutes - Determines the complete timeout in minutes for the tests. Default: 15.</li>
      * <li>additionalDockerArgs - A list containing arguments that are given to docker.</li>
      * <li>additionalCypressArgs - A list containing argument that are given to cypress.</li>
+     * <li>adminGroup - The admin group cypress should use. Default: currentConfig.adminGroup (usually "CesAdministrators").</li>
      */
     void runCypressIntegrationTests(config = [:]) {
-        Cypress cypress = new Cypress(this.script, config)
+        // currentConfig.adminGroup provides the default value, config entries passed as arguments always win on conflict.
+        Cypress cypress = new Cypress(this.script, [adminGroup: currentConfig.adminGroup] + config)
 
         try {
-            cypress.updateCypressConfiguration(vagrant)
             cypress.preTestWork()
             cypress.runIntegrationTests(this)
         } finally {

--- a/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
@@ -324,10 +324,16 @@ class EcoSystem {
      * <li>additionalDockerArgs - A list containing arguments that are given to docker.</li>
      * <li>additionalCypressArgs - A list containing argument that are given to cypress.</li>
      * <li>adminGroup - The admin group cypress should use. Default: currentConfig.adminGroup (usually "CesAdministrators").</li>
+     * <li>adminUsername - The admin username cypress should use. Default: currentConfig.adminUsername.</li>
+     * <li>adminPassword - The admin password cypress should use. Default: currentConfig.adminPassword.</li>
      */
     void runCypressIntegrationTests(config = [:]) {
-        // currentConfig.adminGroup provides the default value, config entries passed as arguments always win on conflict.
-        Cypress cypress = new Cypress(this.script, [adminGroup: currentConfig.adminGroup] + config)
+        // currentConfig provides the default values, config entries passed as arguments always win on conflict.
+        Cypress cypress = new Cypress(this.script, [
+                adminGroup   : currentConfig.adminGroup,
+                adminUsername: currentConfig.adminUsername,
+                adminPassword: currentConfig.adminPassword
+        ] + config)
 
         try {
             cypress.preTestWork()

--- a/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/EcoSystem.groovy
@@ -161,6 +161,7 @@ class EcoSystem {
         script.echo "Changing /config/_global/admin_group to $newGlobalAdminGroup"
         this.vagrant.ssh "etcdctl set /config/_global/admin_group $newGlobalAdminGroup"
 
+        // keep local config in sync
         currentConfig.adminGroup = newGlobalAdminGroup
     }
 

--- a/src/com/cloudogu/ces/dogubuildlib/MultiNodeEcoSystem.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/MultiNodeEcoSystem.groovy
@@ -37,7 +37,8 @@ class MultiNodeEcoSystem extends EcoSystem {
     def multinodeConfig = [
             additionalDogus: [],
             additionalComponents: [],
-            nodeCount: "1"
+            nodeCount: "1",
+            adminGroup: 'cesAdmin'
     ]
 
     /**
@@ -242,10 +243,15 @@ spec:
           | sed "s/^\\([[:space:]]*admin_group:\\).*/\\1 $newGlobalAdminGroup/" \
           | kubectl apply -n ecosystem -f -
         """
+
+        // keep in sync for subsequent integration test runs
+        currentConfig.adminGroup = newGlobalAdminGroup
     }
 
     void runCypressIntegrationTests(config = [:]) {
-        Cypress cypress = new Cypress(this.script, config)
+        // currentConfig.adminGroup (set via multinodeConfig in setup()) provides the default,
+        // config entries always win on conflict.
+        Cypress cypress = new Cypress(this.script, [adminGroup: currentConfig.adminGroup] + config)
 
         def ip = getExternalIP()
         def newUrl = "https://$ip"
@@ -263,7 +269,6 @@ spec:
 
               sed -i "s|baseUrl: .*|baseUrl: \\"${NEW_URL}\\",|" ./integrationTests/cypress.config.*
               sed -i "s|\\"AdminUsername\\": .*|\\"AdminUsername\\": \\"${ADMIN_UN}\\",|" ./integrationTests/cypress.config.*
-              sed -i "s|\\"AdminGroup\\": .*|\\"AdminGroup\\": \\"cesAdmin\\",|" ./integrationTests/cypress.config.*
 
               pw_escaped=$(printf '%s' "$ADMIN_PW" | sed -e 's/[\\\\&|]/\\\\&/g' -e 's/"/\\\\\\"/g')
               sed -i "s|\\"AdminPassword\\": .*|\\"AdminPassword\\": \\"${pw_escaped}\\",|" ./integrationTests/cypress.config.*

--- a/src/com/cloudogu/ces/dogubuildlib/MultiNodeEcoSystem.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/MultiNodeEcoSystem.groovy
@@ -249,29 +249,28 @@ spec:
     }
 
     void runCypressIntegrationTests(config = [:]) {
-        // currentConfig.adminGroup (set via multinodeConfig in setup()) provides the default,
-        // config entries always win on conflict.
-        Cypress cypress = new Cypress(this.script, [adminGroup: currentConfig.adminGroup] + config)
-
         def ip = getExternalIP()
         def newUrl = "https://$ip"
 
-        def adminPW = script.sh(returnStdout: true, script: "coder ssh $coder_workspace \"kubectl get secret ldap-config -n ecosystem -o jsonpath='{.data.config\\.yaml}' | base64 --decode | sed 's/^admin_password:[[:space:]]*//'\"").trim().replaceAll(/^'+|'+$/, "")
         def adminUN = script.sh(returnStdout: true, script: "coder ssh $coder_workspace \"kubectl get configmap ldap-config -n ecosystem -o jsonpath='{.data.config\\.yaml}' | grep '^admin_username:' | cut -d':' -f2 | xargs\"").trim().replaceAll(/^'+|'+$/, "")
+        def adminPW = script.sh(returnStdout: true, script: "coder ssh $coder_workspace \"kubectl get secret ldap-config -n ecosystem -o jsonpath='{.data.config\\.yaml}' | base64 --decode | sed 's/^admin_password:[[:space:]]*//'\"").trim().replaceAll(/^'+|'+$/, "")
+
+        // adminUsername and adminPassword are fetched from k8s
+        // config entries passed as arguments always win on conflict
+        Cypress cypress = new Cypress(this.script, [
+                adminGroup   : currentConfig.adminGroup,
+                adminUsername: adminUN,
+                adminPassword: adminPW
+        ] + config)
+
         script.withEnv([
                 "NEW_URL=${newUrl}",
-                "ADMIN_UN=${adminUN}",
-                "ADMIN_PW=${adminPW}"
         ]) {
             script.sh '''#!/usr/bin/env bash
               set -eu
               set +x
 
               sed -i "s|baseUrl: .*|baseUrl: \\"${NEW_URL}\\",|" ./integrationTests/cypress.config.*
-              sed -i "s|\\"AdminUsername\\": .*|\\"AdminUsername\\": \\"${ADMIN_UN}\\",|" ./integrationTests/cypress.config.*
-
-              pw_escaped=$(printf '%s' "$ADMIN_PW" | sed -e 's/[\\\\&|]/\\\\&/g' -e 's/"/\\\\\\"/g')
-              sed -i "s|\\"AdminPassword\\": .*|\\"AdminPassword\\": \\"${pw_escaped}\\",|" ./integrationTests/cypress.config.*
             '''
         }
         try {

--- a/src/com/cloudogu/ces/dogubuildlib/MultiNodeEcoSystem.groovy
+++ b/src/com/cloudogu/ces/dogubuildlib/MultiNodeEcoSystem.groovy
@@ -244,7 +244,7 @@ spec:
           | kubectl apply -n ecosystem -f -
         """
 
-        // keep in sync for subsequent integration test runs
+        // keep local config in sync
         currentConfig.adminGroup = newGlobalAdminGroup
     }
 

--- a/test/com/cloudogu/ces/dogubuildlib/CypressTest.groovy
+++ b/test/com/cloudogu/ces/dogubuildlib/CypressTest.groovy
@@ -250,10 +250,8 @@ class CypressTest {
         assert mockedScript.writenFileInfo.text == "jenkins:x:1000:1000::/home/jenkins:/bin/sh"
         assert mockedScript.docker.dockerUsedImage == Cypress.defaultIntegrationTestsConfig.cypressImage
         assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro "
-        assert mockedScript.shList[2].contains("cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run -q --headless --config screenshotOnRunFailure=true --config video=true --reporter junit --reporter-options mochaFile=cypress-reports/")
-        assert mockedScript.shList[2].contains(" --env AdminGroup='CesAdministrators'")
-        assert mockedScript.shList[2].contains(" --env AdminUsername='ces-admin'")
-        assert mockedScript.shList[2].contains(" --env AdminPassword='Ecosystem2016!'")
+        assert mockedScript.shList[2].contains("cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run -q --headless --config screenshotOnRunFailure=true,video=true --reporter junit --reporter-options mochaFile=cypress-reports/")
+        assert mockedScript.shList[2].contains(" --env AdminGroup='CesAdministrators',AdminUsername='ces-admin',AdminPassword='Ecosystem2016!'")
     }
 
     //--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro
@@ -293,11 +291,8 @@ class CypressTest {
         assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro ${expectedDockerArgs}"
         assert mockedScript.shList[2].contains("cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run -q --headless")
         assert mockedScript.shList[2].contains(" --reporter junit --reporter-options mochaFile=cypress-reports/")
-        assert mockedScript.shList[2].contains(" --config screenshotOnRunFailure=${expectedRecordScreenshot}")
-        assert mockedScript.shList[2].contains(" --config video=${expectedRecordVideo}")
-        assert mockedScript.shList[2].contains(" --env AdminGroup='CesAdministrators'")
-        assert mockedScript.shList[2].contains(" --env AdminUsername='ces-admin'")
-        assert mockedScript.shList[2].contains(" --env AdminPassword='Ecosystem2016!'")
+        assert mockedScript.shList[2].contains(" --config screenshotOnRunFailure=${expectedRecordScreenshot},video=${expectedRecordVideo}")
+        assert mockedScript.shList[2].contains(" --env AdminGroup='CesAdministrators',AdminUsername='ces-admin',AdminPassword='Ecosystem2016!'")
         assert mockedScript.shList[2].contains(" ${expectedCypressArgs}")
     }
 
@@ -312,7 +307,33 @@ class CypressTest {
         cypress.runIntegrationTests(ecoSystem)
 
         // then
-        assert mockedScript.shList[2].contains(" --env AdminPassword='it'\\''s a secret'")
+        assert mockedScript.shList[2].contains("AdminPassword='it'\\''s a secret'")
+    }
+
+    @Test
+    void testRunCypressIntegrationTestsMergesAdditionalEnv() {
+        // given
+        Cypress cypress = new Cypress(mockedScript, [additionalEnv: [TAGS: "not @ignore"]])
+        when(ecoSystem.getExternalIP()).thenReturn("192.168.56.2")
+
+        // when
+        cypress.runIntegrationTests(ecoSystem)
+
+        // then
+        assert mockedScript.shList[2].contains(" --env AdminGroup='CesAdministrators',AdminUsername='ces-admin',AdminPassword='Ecosystem2016!',TAGS='not @ignore'")
+    }
+
+    @Test
+    void testRunCypressIntegrationTestsAdditionalEnvOverridesBuiltIn() {
+        // given
+        Cypress cypress = new Cypress(mockedScript, [additionalEnv: [AdminGroup: "OverriddenGroup"]])
+        when(ecoSystem.getExternalIP()).thenReturn("192.168.56.2")
+
+        // when
+        cypress.runIntegrationTests(ecoSystem)
+
+        // then
+        assert mockedScript.shList[2].contains(" --env AdminGroup='OverriddenGroup',AdminUsername='ces-admin',AdminPassword='Ecosystem2016!'")
     }
 
     @Test

--- a/test/com/cloudogu/ces/dogubuildlib/CypressTest.groovy
+++ b/test/com/cloudogu/ces/dogubuildlib/CypressTest.groovy
@@ -249,7 +249,7 @@ class CypressTest {
         assert mockedScript.writenFileInfo.file == ".jenkins/etc/passwd"
         assert mockedScript.writenFileInfo.text == "jenkins:x:1000:1000::/home/jenkins:/bin/sh"
         assert mockedScript.docker.dockerUsedImage == Cypress.defaultIntegrationTestsConfig.cypressImage
-        assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro "
+        assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 -e CYPRESS_ADMIN_GROUP=CesAdministrators --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro "
         assert mockedScript.shList[2].contains("cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run -q --headless --config screenshotOnRunFailure=true --config video=true --reporter junit --reporter-options mochaFile=cypress-reports/")
     }
 
@@ -287,7 +287,7 @@ class CypressTest {
         assert mockedScript.writenFileInfo.file == ".jenkins/etc/passwd"
         assert mockedScript.writenFileInfo.text == "jenkins:x:1000:1000::/home/jenkins:/bin/sh"
         assert mockedScript.docker.dockerUsedImage == expectedImage
-        assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro ${expectedDockerArgs}"
+        assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 -e CYPRESS_ADMIN_GROUP=CesAdministrators --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro ${expectedDockerArgs}"
         assert mockedScript.shList[2].contains("cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run -q --headless")
         assert mockedScript.shList[2].contains(" --reporter junit --reporter-options mochaFile=cypress-reports/")
         assert mockedScript.shList[2].contains(" --config screenshotOnRunFailure=${expectedRecordScreenshot}")

--- a/test/com/cloudogu/ces/dogubuildlib/CypressTest.groovy
+++ b/test/com/cloudogu/ces/dogubuildlib/CypressTest.groovy
@@ -249,8 +249,9 @@ class CypressTest {
         assert mockedScript.writenFileInfo.file == ".jenkins/etc/passwd"
         assert mockedScript.writenFileInfo.text == "jenkins:x:1000:1000::/home/jenkins:/bin/sh"
         assert mockedScript.docker.dockerUsedImage == Cypress.defaultIntegrationTestsConfig.cypressImage
-        assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 -e CYPRESS_ADMIN_GROUP=CesAdministrators --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro "
+        assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro "
         assert mockedScript.shList[2].contains("cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run -q --headless --config screenshotOnRunFailure=true --config video=true --reporter junit --reporter-options mochaFile=cypress-reports/")
+        assert mockedScript.shList[2].contains(" --env AdminGroup=CesAdministrators")
     }
 
     //--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro
@@ -287,11 +288,12 @@ class CypressTest {
         assert mockedScript.writenFileInfo.file == ".jenkins/etc/passwd"
         assert mockedScript.writenFileInfo.text == "jenkins:x:1000:1000::/home/jenkins:/bin/sh"
         assert mockedScript.docker.dockerUsedImage == expectedImage
-        assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 -e CYPRESS_ADMIN_GROUP=CesAdministrators --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro ${expectedDockerArgs}"
+        assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro ${expectedDockerArgs}"
         assert mockedScript.shList[2].contains("cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run -q --headless")
         assert mockedScript.shList[2].contains(" --reporter junit --reporter-options mochaFile=cypress-reports/")
         assert mockedScript.shList[2].contains(" --config screenshotOnRunFailure=${expectedRecordScreenshot}")
         assert mockedScript.shList[2].contains(" --config video=${expectedRecordVideo}")
+        assert mockedScript.shList[2].contains(" --env AdminGroup=CesAdministrators")
         assert mockedScript.shList[2].contains(" ${expectedCypressArgs}")
     }
 

--- a/test/com/cloudogu/ces/dogubuildlib/CypressTest.groovy
+++ b/test/com/cloudogu/ces/dogubuildlib/CypressTest.groovy
@@ -251,7 +251,9 @@ class CypressTest {
         assert mockedScript.docker.dockerUsedImage == Cypress.defaultIntegrationTestsConfig.cypressImage
         assert mockedScript.docker.dockerArgs == "--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro "
         assert mockedScript.shList[2].contains("cd integrationTests/ && rm -rf node_modules && yarn install && yarn cypress run -q --headless --config screenshotOnRunFailure=true --config video=true --reporter junit --reporter-options mochaFile=cypress-reports/")
-        assert mockedScript.shList[2].contains(" --env AdminGroup=CesAdministrators")
+        assert mockedScript.shList[2].contains(" --env AdminGroup='CesAdministrators'")
+        assert mockedScript.shList[2].contains(" --env AdminUsername='ces-admin'")
+        assert mockedScript.shList[2].contains(" --env AdminPassword='Ecosystem2016!'")
     }
 
     //--ipc=host -e CYPRESS_BASE_URL=https://192.168.56.2 --entrypoint='' -v /home/jenkins/.jenkins/etc/passwd:/etc/passwd:ro
@@ -293,8 +295,24 @@ class CypressTest {
         assert mockedScript.shList[2].contains(" --reporter junit --reporter-options mochaFile=cypress-reports/")
         assert mockedScript.shList[2].contains(" --config screenshotOnRunFailure=${expectedRecordScreenshot}")
         assert mockedScript.shList[2].contains(" --config video=${expectedRecordVideo}")
-        assert mockedScript.shList[2].contains(" --env AdminGroup=CesAdministrators")
+        assert mockedScript.shList[2].contains(" --env AdminGroup='CesAdministrators'")
+        assert mockedScript.shList[2].contains(" --env AdminUsername='ces-admin'")
+        assert mockedScript.shList[2].contains(" --env AdminPassword='Ecosystem2016!'")
         assert mockedScript.shList[2].contains(" ${expectedCypressArgs}")
+    }
+
+    @Test
+    void testRunCypressIntegrationTestsEscapesAdminPasswordWithSingleQuoteWrap() {
+        // given
+        String passwordWithQuote = "it's a secret"
+        Cypress cypress = new Cypress(mockedScript, [adminPassword: passwordWithQuote])
+        when(ecoSystem.getExternalIP()).thenReturn("192.168.56.2")
+
+        // when
+        cypress.runIntegrationTests(ecoSystem)
+
+        // then
+        assert mockedScript.shList[2].contains(" --env AdminPassword='it'\\''s a secret'")
     }
 
     @Test


### PR DESCRIPTION
This change fixes a config-/env-file cross-contamination bug when running classic and multi-node tests in parallel on the same worker.

The classic test setup cypress.env.json (written by EcoSystem.updateCypressConfiguration()) was silently overriding MultiNodeEcoSystem's sed-patched AdminGroup value in shared Jenkins workspaces.

The fix stops relying on shared files for this one value and instead passes AdminGroup per-container via a CYPRESS_ADMIN_GROUP env var.

This behavior mirrors the existing CYPRESS_BASE_URL pattern in Cypress.groovy.

The ENV-var approach replaces and deprecates `updateCypressConfiguration`. The function is not used anywhere else in the GitHub Orga and could be removed too.
https://github.com/search?q=org%3Acloudogu%20updateCypressConfiguration&type=code